### PR TITLE
Dockerfile: build frontend (fixes #10).

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+./demo/build/

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 # next.js build output
 .next
+./demo/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
 FROM node:12
-WORKDIR /usr/app
+
+WORKDIR /usr/app/
 COPY package*.json ./
 RUN npm ci --only=production
+
+WORKDIR /usr/app/demo/
+COPY demo/package*.json ./
+RUN npm install
+
+WORKDIR /usr/app/
 COPY . .
+
+RUN \
+  cd ./demo/ && \
+  yarn build
+
 EXPOSE 3000
 CMD node lib/index.js config.json


### PR DESCRIPTION
Add frontend generation on Docker build (proposal).

Basically, it adds:
* `npm install` on `demo` dir.
* `yarn build` at the end of the build.

The﻿se steps are done separately to take advantage of Docker image build layer caching.
For every statement in the Dockerfile, the build uses the cache if no file referenced has changed.
This is why we add `package*` files in their own statements first, so subsequient `npm ci`/`npm install` can use cache if no changes have been done to them.

Also, since they will be rebuilt on each time, I've `.dockerignore`'d the `build` dir. I guess that it should be the same for the git repo, so I'd also `.gitignore`'d it, too.	I've not deleted the dir in case it's used in some other workflow I'm not aware. I leave it up to you.

Notice that I might have took some decision or approach which can not be entirely fit due to my limitations with NodeJS. So, maybe some tweaks after your feedback may be necessary.
