### PR TITLE
Sample config.json file improvements

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,11 @@
 {
     "$schema": "./src/config.schema.json",
-    "host": "w",
+    "host": "0.0.0.0",
+    "port": 3000,
     "torrents": {
-        "useDefaultTrackers": false,
-        "peerAddresses": ["wqwe"]
+        "useDefaultTrackers": true,
+        "peerAddresses": [
+            "transmission:51413"
+        ]
     }
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,6 @@
     "host": "0.0.0.0",
     "port": 3000,
     "torrents": {
-        "useDefaultTrackers": true,
         "peerAddresses": [
             "transmission:51413"
         ]


### PR DESCRIPTION
* Fix breaking `host` value.
* Add `port` sample value.
* Enable tracker adding, as opposed of default disabled.
* Add a dummy `x.pe` sample entry (nothing breaks if host is not reachable).

The sample `x.pe` entry might be useful 'as is' when running within Docker and linked to a transmission daemon container with default port config.