### PR TITLE
Dockerfile: speed up repeated builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM node:12
 
 WORKDIR /usr/app
+
 COPY package*.json ./
 RUN npm ci --ignore-scripts
+
+COPY frontend/package*.json frontend/
+RUN npm ci --prefix frontend/
+
 COPY tsconfig.json ./
 COPY src/ src/
 RUN npm run build-backend
 
-COPY frontend/package*.json frontend/
-RUN npm ci --prefix frontend/
 COPY frontend/tsconfig.json frontend/
 COPY frontend/src/ frontend/src/
 COPY frontend/public/ frontend/public/


### PR DESCRIPTION
I use Docker for my development and testing ﻿workflow. Every time I `docker build` and test.
Docker tries to speed up image building by reusing build cache layers. However, if any step (layer) has files changed, that layer and the subsequent are rebuilt.
As of now, the frontend `npm ci` is rerun every time backend code changes, since its layer is invalidated in previous steps.
Since *both* (back & front) `package*` files change way less than others, I've moved them at th beginning.
So far, it builds OK and the service works without problem. However, I can't tell if there are further implications, feedback welcome.
