### PR TITLE
Dockerfile: use ENTRYPOINT instead of CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY frontend/public/ frontend/public/
 RUN npm run build-frontend && rm -rf ./frontend/node_modules
 
 EXPOSE 3000
-CMD node . serve
+ENTRYPOINT [ "node", ".", "serve" ]


### PR DESCRIPTION
Running the program using `CMD` causes a `bash -c` stub to be launched as `node` parent process. Also, `node` will not receive any signals (including `SIGTERM`), since they will go to the container's PID 1 (`bash`).
Running `node` as an `ENTRYPOINT` makes it PID 1, avoiding `bash` completely.
More info: https://stackoverflow.com/questions/21553353/what-is-the-difference-between-cmd-and-entrypoint-in-a-dockerfile


Also, as of now, the Docker container is run like this:
```
$ docker run ghcr.io/kiralt/torrent-stream-server
```
Since no further command line switches are given after the image name, Docker assumes the `CMD` statement (`node . serve`).
As it is now, adding any command line switches at container launch (eg. `--version`), since they replace `CMD`, would require to be aware of the existing `CMD` and do this:
```
$ docker run ghcr.io/kiralt/torrent-stream-server node . serve --version
```
However, if `ENTRYPOINT` is used, `docker run` command line parameters will not overwrite nothing and it would be easy as this:
```
$ docker run ghcr.io/kiralt/torrent-stream-server --version
```
The `ENTRYPOINT` is preserved (unless you deliberately use the `--entrypoint` switch with `docker run`).

Also, after improving this, I guess a tagged version image release would be desirable, especially since latest `:1.5.1`, non-`:latest` tag is broken (starts and exits immediately). And since it is listed in the releases sidebar on GitHub, someone might use it. Using a non-`:latest`, versioned image tag is a Docker recommended practice. `:latest` image tag works OK, since it's built straight from `master` git branch. Make sure that `:latest` image tag -> `master` git branch (aka, devel build) is what you want. Alternatively, you can make `:latest` -> latest stable version and create a `:devel` or similar for HEAD, edge builds. Both are OK, but keep it in mind.
﻿
