### PR TITLE
Add Docker Compose manifest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "2.4"
+services:
+  torrent-stream-server:
+    container_name: torrent-stream-server
+    restart: unless-stopped
+
+# Use 'build' instead of 'image' for building from local source:
+#    build: .
+    image: ghcr.io/kiralt/torrent-stream-server
+# Add optional command line switches:
+#    command: [ "-c", "config.json" ]
+
+    environment:
+      - HOST
+# You can either expose host's env vars or explicitly set them:
+      - PORT
+#      - PORT=80
+
+# You can use host networking mode instead of port mapping:
+#    network_mode: host
+    ports:
+      - "3000:3000"
+
+# The 'config.json' file in the repo is mounted. To use it, make sure
+# you set the appropriate '-c' switch in the 'command' section.
+    volumes:
+      - type: bind
+        source: ${PWD}/config.json
+        target: /usr/app/config.json
+        read_only: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,6 +6,12 @@ One-click ready-to-code development environments:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/KiraLT/torrent-stream-server)
 
+## Using Docker & Docker Compose
+Docker and Docker Compose required. NodeJS **not** required on development host.
+
+* Edit `docker-compose.yml` to tailor to your needs (make sure `build: .` is uncommented).
+* Run `docker-compose up --build [--force-recreate]`.
+
 ## From Source
 
 > Frontend & backend are separate packages.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -60,7 +60,7 @@ Go to http://127.0.0.1:3000
 
 [![Docker](https://github.com/KiraLT/torrent-stream-server/workflows/Docker/badge.svg?branch=master)](https://github.com/users/KiraLT/packages/container/package/torrent-stream-server)
 
-This will start a new instance with latest version listening on `3000` port (see [all versions](https://github.com/users/KiraLT/packages/container/torrent-stream-server/versions)). 
+This will start a new instance with latest version listening on `3000` port (see [all versions](https://github.com/users/KiraLT/packages/container/torrent-stream-server/versions)).
 
 ```shell
 docker run -d --name torrent-stream-server ghcr.io/kiralt/torrent-stream-server:latest
@@ -75,3 +75,10 @@ docker run -d --name torrent-stream-server -p 80:3000 ghcr.io/kiralt/torrent-str
 ```
 
 You'll be able to access it on http://localhost
+
+### Using Docker Compose
+You can also use the provided [Docker Compose manifest](../docker-compose.yml). Customize as needed by editing and run:
+```shell
+docker-compose up -d
+```
+Also, you can use the provided manifest as a reference for Docker deployment.


### PR DESCRIPTION
After having a proper Docker image, we can use Docker Compose for providing easy deployment and customization of containers.
If I find any Docker Compose manifest in a repo, I use it to spin up the software instantly. I use it also to learn and tweak options when deploying.

I've commented the manifest﻿ to make it self-documenting and hopefully be the, comprehensive, single stop for Docker users.
Let's see if it's self-explaining enough and please check the manifest & docs. Do not hesitate to give feedback and questions.
